### PR TITLE
Add stopStatusPolling and clean polling logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,7 +328,9 @@
         const logsCount = document.getElementById('logs-count');
         const currentCount = parseInt(logsCount.textContent);
         logsCount.textContent = currentCount + 1;
-      }
+        }
+
+      let currentPollId = null;
 
       // Função centralizada para fazer chamadas ao webhook
       async function callWebhook(action, data = {}) {
@@ -384,8 +386,8 @@
           document.getElementById('error-display').classList.add('hidden');
           document.getElementById('disconnected-warning').classList.add('hidden');
           addLog('QR Code gerado com sucesso!', 'success');
-          stopStatusPolling(window.currentPollId);
-          window.currentPollId = startStatusPolling(instance, info, true);
+          stopStatusPolling(currentPollId);
+          currentPollId = startStatusPolling(instance, info, true);
         } catch (error) {
           addLog('Erro ao gerar QR Code: ' + error.message, 'error');
         }
@@ -984,6 +986,12 @@
           }
         }, interval);
         return pollId;
+      }
+
+      function stopStatusPolling(pollId) {
+        if (pollId) {
+          clearInterval(pollId);
+        }
       }
 
       // Função para verificar o estado da conexão


### PR DESCRIPTION
## Summary
- allow stopping status polling via new `stopStatusPolling` function
- use a simple `currentPollId` variable instead of `window.currentPollId`

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68476dc8b1148323a0671b5b9c4b42dc