### PR TITLE
Fix QR code canvas rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,8 +376,25 @@
         try {
           addLog('Gerando QR Code...', 'info');
           const response = await callWebhook('connect', { instance });
-          const qrCode = response[0].data.qrcode;
-          document.getElementById('qr-code').src = qrCode;
+          const qrData = response[0].data.qrcode || response[0].data.code;
+
+          const canvas = document.getElementById('qrcodeCanvas');
+          document.getElementById('loading-spinner').classList.add('hidden');
+          canvas.style.display = 'block';
+
+          if (qrData) {
+            QRCode.toCanvas(
+              canvas,
+              qrData,
+              { width: 180, height: 180, margin: 0 },
+              function (error) {
+                if (error) {
+                  addLog(`Erro ao gerar QR Code: ${error.message}`, 'error');
+                }
+              }
+            );
+          }
+
           document.getElementById('connection-form').classList.add('hidden');
           document.getElementById('qr-display').classList.remove('hidden');
           document.getElementById('status-display').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- use the existing `qrcodeCanvas` element when generating the QR code

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68476dc9911c832396f2217e64f77e1c